### PR TITLE
Implement manual request feature for term explanations 

### DIFF
--- a/Backend/AI/SmallModel.py
+++ b/Backend/AI/SmallModel.py
@@ -232,18 +232,23 @@ Repeat: the user's role is "{user_role}". Adjust the confidence and terms accord
                         current_queue = json.loads(content)
             
             for term_data in detected_terms:
-                current_queue.append({
+                entry = {
                     "id": str(uuid4()),
                     "term": term_data["term"], 
                     "context": term_data["context"], 
-                    "confidence": term_data["confidence"],
                     "timestamp": term_data["timestamp"], 
                     "client_id": message.client_id,
                     "user_session_id": message.payload.get("user_session_id"),
                     "original_message_id": message.id, 
                     "status": "pending", 
                     "explanation": None
-                })
+                }
+                # Include confidence only when provided by producer (e.g., AI detection),
+                # manual requests may omit it deliberately.
+                if "confidence" in term_data and term_data["confidence"] is not None:
+                    entry["confidence"] = term_data["confidence"]
+
+                current_queue.append(entry)
 
             temp_file = self.detections_queue_file.with_suffix('.tmp')
             async with aiofiles.open(temp_file, 'w', encoding='utf-8') as f:

--- a/Backend/MessageRouter.py
+++ b/Backend/MessageRouter.py
@@ -135,7 +135,6 @@ class MessageRouter:
                         detected_terms = [{
                             "term": term,
                             "timestamp": int(time.time()),
-                            "confidence": 0.4,
                             "context": context,
                         }]
                         success = await self._small_model.write_detection_to_queue(message, detected_terms)

--- a/Backend/tests/test_manual_request.py
+++ b/Backend/tests/test_manual_request.py
@@ -1,0 +1,49 @@
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from Backend.MessageRouter import MessageRouter
+from Backend.models.UniversalMessage import UniversalMessage
+from Backend.core.Queues import queues
+
+
+@pytest.mark.asyncio
+async def test_manual_request_writes_detection(tmp_path: Path, monkeypatch):
+    # Arrange: point SmallModel to a temporary detections file
+    detections_file = tmp_path / "detections_queue.json"
+
+    router = MessageRouter()
+
+    # Monkeypatch SmallModel's detections file path
+    router._small_model.detections_queue_file = detections_file
+
+    # Ensure router is in running state for consistency
+    router._running = True
+
+    # Build a manual.request message
+    msg = UniversalMessage(
+        type='manual.request',
+        payload={'term': 'OAuth', 'context': 'Auth standard'},
+        origin='test',
+        destination=None,
+        client_id=f'frontend_renderer_{uuid4()}'
+    )
+
+    # Act: process the client message
+    await router._process_client_message(msg)
+
+    # Assert: the detections file exists and contains our entry
+    assert detections_file.exists(), "Detections file should be created"
+    data = json.loads(detections_file.read_text(encoding='utf-8'))
+    assert isinstance(data, list) and len(data) >= 1
+    last = data[-1]
+    assert last["term"] == 'OAuth'
+    assert last["context"] == 'Auth standard'
+    assert last["status"] == 'pending'
+    assert last["client_id"] == msg.client_id
+    assert last.get("timestamp") is not None

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -25,6 +25,18 @@ This starts:
 
 (For Electron developement only. Will not start the Backend and a Websocket connections will not be possible. Use `run_electron.py` script in root folder instead.)
 
+## Manual Explain Feature
+
+In the Explanations tab, you can directly request an explanation for any term:
+
+- Enter a term in the "Explain a term" field and click "Explain" (or press Enter).
+- The app sends a `manual.request` message to the backend.
+- The backend enqueues the term into the detection pipeline; once processed, a new explanation appears automatically in the list.
+
+Notes:
+- Requires an active WebSocket connection to the backend at `ws://localhost:8000`.
+- The pipeline uses the same MainModel and ExplanationDeliveryService as automatic detections.
+
 ## Folder structure
 
 ```

--- a/Frontend/src/renderer.js
+++ b/Frontend/src/renderer.js
@@ -193,10 +193,12 @@ class ElectronMyElement extends UI {
     import('./shared/explanation-manager.js').then(({ explanationManager }) => {
       if (explanation && explanation.term && explanation.content) {
         // Add explanation to the manager
+        const confidence = typeof explanation.confidence === 'number' ? explanation.confidence : null;
         explanationManager.addExplanation(
           explanation.term,
           explanation.content,
-          explanation.timestamp * 1000 // Convert to milliseconds if needed
+          explanation.timestamp * 1000, // Convert to milliseconds if needed
+          confidence
         );
 
         // Show notification about new explanation

--- a/Frontend/src/shared/explanation-item.js
+++ b/Frontend/src/shared/explanation-item.js
@@ -21,6 +21,7 @@ export class ExplanationItem extends LitElement {
           <div class="explanation-title">
             ${this.explanation.isPinned ? html`<span class="pinned-indicator material-icons">push_pin</span>` : ''}
             ${this.explanation.title}
+            ${this._renderConfidenceBadge(this.explanation.confidence)}
           </div>
           <div class="explanation-actions" @click=${this._stopPropagation}>
             <button class="action-button pin-button ${this.explanation.isPinned ? 'pinned' : ''}" @click=${this._handlePin} title="${this.explanation.isPinned ? 'Unpin' : 'Pin'} explanation">
@@ -74,6 +75,20 @@ export class ExplanationItem extends LitElement {
     if (!timestamp) return '';
     const date = new Date(timestamp);
     return date.toLocaleString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+  }
+
+  _renderConfidenceBadge(confidence) {
+    if (typeof confidence !== 'number' || !isFinite(confidence)) return html``;
+    const clamped = Math.max(0, Math.min(1, confidence));
+    const pct = Math.round(clamped * 100);
+    const level = this._confidenceLevel(pct);
+    return html`<span class="confidence-badge ${level}" title="Confidence: ${pct}%">${pct}%</span>`;
+  }
+
+  _confidenceLevel(percent) {
+    if (percent >= 75) return 'high';
+    if (percent >= 50) return 'medium';
+    return 'low';
   }
 }
 customElements.define('explanation-item', ExplanationItem);

--- a/Frontend/src/shared/index.css
+++ b/Frontend/src/shared/index.css
@@ -228,6 +228,24 @@ md-tabs {
 	font-weight: 500;
 }
 
+/* Confidence badge */
+.confidence-badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	margin-left: var(--space-sm);
+	padding: 2px 8px;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	line-height: 1;
+	min-width: 34px;
+	user-select: none;
+}
+.confidence-badge.low { background: #D32F2F; color: #fff; }
+.confidence-badge.medium { background: #F59E0B; color: #111827; }
+.confidence-badge.high { background: #2E7D32; color: #fff; }
+
 .explanation-actions {
 	display: flex;
 	gap: var(--space-xs);

--- a/Frontend/src/shared/index.css
+++ b/Frontend/src/shared/index.css
@@ -361,4 +361,4 @@ md-outlined-text-field md-icon-button[slot="trailing-icon"] .material-icons {
 .expand-icon.expanded .material-icons { transform: rotate(180deg); }
 .copy-button .material-icons { font-size: 16px; }
 .empty-icon.material-icons { font-size: 72px; margin-bottom: var(--space-lg); opacity: 0.6; }
-md-text-button .material-icons, md-filled-button .material-icons { font-size: 18px; margin-right: var(--space-xs); }
+md-text-button .material-icons, md-filled-button .material-icons, md-outlined-button .material-icons { font-size: 18px; margin-right: var(--space-xs); }

--- a/Frontend/src/shared/ui.js
+++ b/Frontend/src/shared/ui.js
@@ -93,18 +93,31 @@ export class UI extends LitElement {
                 .value=${this.manualTerm}
                 @input=${this._onManualTermInput}
                 @keydown=${this._onManualKeyDown}
-              ></md-outlined-text-field>
-              <md-filled-button
-                id="manual-send-button"
-                @click=${this._sendManualRequest}
-                ?disabled=${!(this.manualTerm && this.manualTerm.trim())}
-              >Explain</md-filled-button>
-              <md-text-button @click=${this._clearAllExplanations}><span class="material-icons">delete</span> Clear All</md-text-button>
-              <md-filled-button @click=${this._addTestExplanation}><span class="material-icons">add</span> Add Test</md-filled-button>
+              >
+                <md-icon-button
+                  id="manual-send-button"
+                  slot="trailing-icon"
+                  class="accent"
+                  title="Send"
+                  aria-label="Send"
+                  @click=${this._sendManualRequest}
+                  ?disabled=${!(this.manualTerm && this.manualTerm.trim())}
+                >
+                  <span class="material-icons">send</span>
+                </md-icon-button>
+              </md-outlined-text-field>
+              <md-outlined-button @click=${this._clearAllExplanations}>
+                <span class="material-icons" slot="icon">delete</span>
+                Clear All
+              </md-outlined-button>
+              <md-filled-button @click=${this._addTestExplanation}>
+                <span class="material-icons" slot="icon">add</span>
+                Add Test
+              </md-filled-button>
             </div>
           </div>
           <div class="explanations-content">
-            ${this.explanations.length===0 ? html`<div class="empty-state"><p>No explanations yet.</p></div>` : html`<div class="explanations-list">
+            ${this.explanations.length===0 ? html`<div class="empty-state"><p>No explanations yet. Ask for a explanation or wait for one to be generated.</p></div>` : html`<div class="explanations-list">
               ${this.explanations.map(explanation => html`<explanation-item .explanation=${explanation} .onPin=${this._handlePin.bind(this)} .onDelete=${this._handleDelete.bind(this)} .onCopy=${this._handleCopy.bind(this)}></explanation-item>`) }
             </div>`}
           </div>
@@ -198,6 +211,6 @@ export class UI extends LitElement {
     .explanations-controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .explanations-controls md-outlined-text-field.manual-term-input { flex: 1 1 280px; min-width: 220px; width: auto; margin: 0; }
     .explanations-controls md-filled-button,
-    .explanations-controls md-text-button { flex: 0 0 auto; white-space: nowrap; }
+    .explanations-controls md-outlined-button { flex: 0 0 auto; white-space: nowrap; }
   ` ];
 }

--- a/Frontend/src/shared/ui.js
+++ b/Frontend/src/shared/ui.js
@@ -16,8 +16,8 @@ import '@material/web/select/select-option.js';
 import '@material/web/dialog/dialog.js';
 
 export class UI extends LitElement {
-  static properties = { activeTab: { type: Number }, domainValue: { type: String }, explanations: { type: Array }, isWindows: { type: Boolean } };
-  constructor() { super(); this.activeTab = 0; this.domainValue=''; this.explanations=[]; this.isWindows=false; this._explanationListener=(exps)=>{ this.explanations=[...exps]; }; explanationManager.addListener(this._explanationListener); }
+  static properties = { activeTab: { type: Number }, domainValue: { type: String }, explanations: { type: Array }, isWindows: { type: Boolean }, manualTerm: { type: String } };
+  constructor() { super(); this.activeTab = 0; this.domainValue=''; this.explanations=[]; this.isWindows=false; this.manualTerm=''; this._explanationListener=(exps)=>{ this.explanations=[...exps]; }; explanationManager.addListener(this._explanationListener); }
   disconnectedCallback() { super.disconnectedCallback(); explanationManager.removeListener(this._explanationListener); }
   render() {
     return html`<div class="ui-host">
@@ -84,15 +84,28 @@ export class UI extends LitElement {
       case 1:
         return html`<div class="tab-panel explanations-panel">
           <div class="explanations-header">
-            <h2 class="headline-medium ocean-accent-text">AI Explanations</h2>
             <div class="explanations-controls">
+              <md-outlined-text-field
+                id="manual-term-input"
+                class="manual-term-input"
+                label="Explain a term"
+                placeholder="e.g. OAuth, ROI, Kafka"
+                .value=${this.manualTerm}
+                @input=${this._onManualTermInput}
+                @keydown=${this._onManualKeyDown}
+              ></md-outlined-text-field>
+              <md-filled-button
+                id="manual-send-button"
+                @click=${this._sendManualRequest}
+                ?disabled=${!(this.manualTerm && this.manualTerm.trim())}
+              >Explain</md-filled-button>
               <md-text-button @click=${this._clearAllExplanations}><span class="material-icons">delete</span> Clear All</md-text-button>
               <md-filled-button @click=${this._addTestExplanation}><span class="material-icons">add</span> Add Test</md-filled-button>
             </div>
           </div>
           <div class="explanations-content">
             ${this.explanations.length===0 ? html`<div class="empty-state"><p>No explanations yet.</p></div>` : html`<div class="explanations-list">
-              ${this.explanations.map(explanation => html`<explanation-item .explanation=${explanation} .onPin=${this._handlePin.bind(this)} .onDelete=${this._handleDelete.bind(this)} .onCopy=${this._handleCopy.bind(this)}></explanation-item>`)}
+              ${this.explanations.map(explanation => html`<explanation-item .explanation=${explanation} .onPin=${this._handlePin.bind(this)} .onDelete=${this._handleDelete.bind(this)} .onCopy=${this._handleCopy.bind(this)}></explanation-item>`) }
             </div>`}
           </div>
         </div>`;
@@ -106,6 +119,9 @@ export class UI extends LitElement {
   _resetSettings(){ this.domainValue=''; }
   _startSession(){ console.warn('UI: _startSession() clicked, but not implemented. Must be overridden in child class.'); }
   _joinSession(){ console.warn('UI: _joinSession() clicked, but not implemented. Must be overridden in child class.'); }
+  _onManualTermInput(e){ this.manualTerm = e.target.value; }
+  _onManualKeyDown(e){ if(e.key === 'Enter'){ e.preventDefault(); this._sendManualRequest(); } }
+  _sendManualRequest(){ console.warn('UI: _sendManualRequest() called, but not implemented. Must be overridden in child class.'); }
   _handlePin(id){ explanationManager.pinExplanation(id); }
   _handleDelete(id){ explanationManager.deleteExplanation(id); }
   _handleCopy(explanation){ const textToCopy = `**${explanation.title}**\n\n${explanation.content}`; navigator.clipboard.writeText(textToCopy); }
@@ -177,5 +193,11 @@ export class UI extends LitElement {
       white-space: nowrap; /* Button-Text nicht umbrechen */
     }
     .dialog-code { color: var(--md-sys-color-primary); font-family: 'Roboto Mono', monospace; letter-spacing: 2px; font-size: 2em; text-align: center; margin-top: 8px; user-select: all; }
+    /* Explanations controls layout */
+    .explanations-header { margin-bottom: 12px; }
+    .explanations-controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .explanations-controls md-outlined-text-field.manual-term-input { flex: 1 1 280px; min-width: 220px; width: auto; margin: 0; }
+    .explanations-controls md-filled-button,
+    .explanations-controls md-text-button { flex: 0 0 auto; white-space: nowrap; }
   ` ];
 }

--- a/Frontend/src/shared/ui.js
+++ b/Frontend/src/shared/ui.js
@@ -111,6 +111,10 @@ export class UI extends LitElement {
   _handleCopy(explanation){ const textToCopy = `**${explanation.title}**\n\n${explanation.content}`; navigator.clipboard.writeText(textToCopy); }
   _clearAllExplanations(){ if (confirm('Are you sure you want to clear all explanations?')) { explanationManager.clearAll(); } }
   _addTestExplanation(){ explanationManager.addExplanation('Test','This is a test explanation.'); }
+  _addTestExplanation(){
+    const rand = Math.random() * 0.6 + 0.2; // 0.2 - 0.8 for variety
+    explanationManager.addExplanation('Test', 'This is a test explanation.', Date.now(), rand);
+  }
   // Window control handlers
   async _winMinimize(){ try{ await window.electronAPI?.windowControls?.minimize(); }catch(e){} }
   async _winToggleMaximize(){


### PR DESCRIPTION
This pull request introduces a new "Manual Explain" feature, allowing users to request explanations for specific terms directly from the frontend. The changes span both the frontend and backend, enabling users to submit a term for explanation, which is then processed by the backend and delivered through the existing explanation pipeline. The most important changes are grouped below by theme.

**Manual Explain Feature Implementation**

* Frontend UI: Added a new input field and button in the Explanations tab for users to enter a term and request an explanation. The UI handles user input, button state, and sends a `manual.request` message to the backend via WebSocket. (`Frontend/src/shared/ui.js`: [[1]](diffhunk://#diff-5a1473f46bc291bcf08d57e9a877f64aa39bec19315ec909ff65f0b7a04eae5fL87-R101) [[2]](diffhunk://#diff-5a1473f46bc291bcf08d57e9a877f64aa39bec19315ec909ff65f0b7a04eae5fR122-R124) [[3]](diffhunk://#diff-5a1473f46bc291bcf08d57e9a877f64aa39bec19315ec909ff65f0b7a04eae5fR192-R197); `Frontend/src/renderer.js`: [[4]](diffhunk://#diff-0c5815abc584f383297e8643316fad2fe31ae6a5f09cf842780c03074cc4e927R132-R166)
* Frontend Logic: Stores the user session ID for inclusion in requests and manages the manual term input state. (`Frontend/src/renderer.js`: [[1]](diffhunk://#diff-0c5815abc584f383297e8643316fad2fe31ae6a5f09cf842780c03074cc4e927R116); `Frontend/src/shared/ui.js`: [[2]](diffhunk://#diff-5a1473f46bc291bcf08d57e9a877f64aa39bec19315ec909ff65f0b7a04eae5fL19-R20)
* Backend Routing: Added support for handling `manual.request` messages, validating input, and enqueuing the term into the detection pipeline for explanation. (`Backend/MessageRouter.py`: [Backend/MessageRouter.pyR127-R149](diffhunk://#diff-a5b78ed9c16757c08087351923ba2428ab57a19e57cc8bdcd4d24be20dfe6523R127-R149))

**Documentation and Testing**

* Documentation: Updated the frontend README to describe the new manual explain workflow and requirements for backend connectivity. (`Frontend/README.md`: [Frontend/README.mdR28-R39](diffhunk://#diff-e2f294f15b078171cb2f525932bb8e4d58436b33090ab5e09b16a6a9f792ae7cR28-R39))
* Backend Test: Added an async test to verify that a `manual.request` results in a correct detection entry in the backend queue. (`Backend/tests/test_manual_request.py`: [Backend/tests/test_manual_request.pyR1-R49](diffhunk://#diff-cbef0f742acd6ac8726f5981200b37135b776523d97e6eae4852c9da01c67dbdR1-R49))