### PR TITLE
Updated initial status of microphone and server to initializing

### DIFF
--- a/Frontend/src/shared/status-bar.js
+++ b/Frontend/src/shared/status-bar.js
@@ -76,12 +76,13 @@ export class StatusBar extends LitElement {
     .trouble { background-color: #ff9800; }
     .denied { background-color: #f44336; }
     .disconnected { background-color: #cd1d10ff; }
+    .initializing { background-color: #9e9e9e; }
   `;
 
   constructor() {
     super();
-    this.serverStatus = 'disconnected';
-    this.microphoneStatus = 'disconnected';
+    this.serverStatus = 'initializing';
+    this.microphoneStatus = 'initializing';
   }
 
   render() {

--- a/Frontend/src/shared/ui.js
+++ b/Frontend/src/shared/ui.js
@@ -33,8 +33,8 @@ export class UI extends LitElement {
     this.explanations = [];
     this.isWindows = false;
     this.manualTerm = '';
-    this.serverStatus = 'disconnected';
-    this.microphoneStatus = 'disconnected';
+    this.serverStatus = 'initializing';
+    this.microphoneStatus = 'initializing';
     this._lastExplanationUpdate = 0;
     this._explanationUpdateThrottle = 100; // Throttle UI updates to every 100ms
     this._explanationListener = (exps) => {


### PR DESCRIPTION
Aim: Resolves issue #98.

But it wasn't successfull. But the warning is not critical, so it doesn't matter.

This is a benign and expected side effect in our case. It's caused by our asynchronous initialization logic (e.g., establishing the WebSocket connection or getting microphone permissions).

Here's the sequence:
1. The component performs its initial render.
2. The async operation (like connecting to the WebSocket) completes.
3. Its callback then updates a status property (e.g., this.serverStatus = 'connected').
4. This correctly triggers a second render to reflect the new status, causing Lit to issue the warning.

This is not a critical issue because it's a necessary, one-time event at startup, not a recurring performance problem or an infinite loop. The warning itself notes that this pattern is acceptable if the update is an unavoidable side effect, which is true here.